### PR TITLE
fix: after remove cannot build release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    main: ./cmd/fl
+    main: .
     goos:
       - linux
       - darwin


### PR DESCRIPTION
After changing org the main.go was also moved to the repo root and this
broke the release process as it was looking for the main.go in `cmd/fl`.

Signed-off-by: Richard Case <richard@weave.works>